### PR TITLE
Move $FILTERED_IPS before 'allow:any'

### DIFF
--- a/block_ddos.sh
+++ b/block_ddos.sh
@@ -14,7 +14,7 @@ echo "VDATE $VDATE"
 
 
 #get the previous minute, to make grep filter on that
-time_to_filter=$(date +'[%d/%b/%Y:%H:%M:%S' --date="$VDATE")
+time_to_filter=$(date +'[%d/%b/%Y:%H:%M:%S]' --date="$VDATE")
 
 echo "Time to filter $time_to_filter"
 

--- a/block_ddos.sh
+++ b/block_ddos.sh
@@ -26,8 +26,8 @@ echo "filtered $FILTERED_IPS"
 
 
 #run platform httpaccess to block ip's that appear more than x times
-echo "platform httpaccess --access allow:any $FILTERED_IPS --no-wait --yes"
-platform httpaccess --access allow:any $FILTERED_IPS --no-wait --yes
+echo "platform httpaccess $FILTERED_IPS --access allow:any --no-wait --yes"
+platform httpaccess $FILTERED_IPS --access allow:any --no-wait --yes
 
 
 


### PR DESCRIPTION
Per Anders Savill at Platform.sh:

```All platform http services are backed by nginx and follow the same nginx blocklist rule process which is top to bottom. Once the IP matches a rule it is applied and the rest of the blocklist is not used. As your first rule on the list is 0.0.0.0/0 allow all IPs match this rule and the rest of the rules do not get processed. If you move the allow rule to the bottom of the list you should see the desired effect.```